### PR TITLE
Fix PortRegistration race causing heap corruption on plugin removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,9 @@ The commands supported by mod-host are:
         * set the MIDI channel which changes pedalboard snapshots on MIDI program change. <midi_channel> is in the range of [0,15].
         e.g.: set_midi_program_change_pedalboard_snapshot_channel 1 4 to enable listening for preset changes on channel 5
 
-    cc_map <instance_number> <param_symbol> <device_id> <actuator_id> <label> <value> <minimum> <maximum> <steps> <unit> <scalepoints_count> <scalepoints...>
+    cc_map <instance_number> <param_symbol> <device_id> <actuator_id> <label> <value> <minimum> <maximum> <steps> <extraflags> <unit> <scalepoints_count> <scalepoints...>
         * map a Control Chain actuator to a control port
-        e.g.: cc_map 0 "gain" 0 1 "Gain" 0.0 -24.0 3.0 33 "dB" 0
+        e.g.: cc_map 0 "gain" 0 1 "Gain" 0.0 -24.0 3.0 33 0 "dB" 0
 
     cc_unmap <instance_number> <param_symbol>
         * unmap the Control Chain actuator from a control port

--- a/README.md
+++ b/README.md
@@ -300,12 +300,16 @@ If status is a negative number an error has occurred. The table below shows the 
 | -204    | ERR\_JACK\_PORT\_REGISTER        |
 | -205    | ERR\_JACK\_PORT\_CONNECTION      |
 | -206    | ERR\_JACK\_PORT\_DISCONNECTION   |
+| -207    | ERR\_JACK\_VALUE\_OUT\_OF\_RANGE |
 | -301    | ERR\_ASSIGNMENT\_ALREADY\_EXISTS |
 | -302    | ERR\_ASSIGNMENT\_INVALID\_OP     |
 | -303    | ERR\_ASSIGNMENT\_LIST\_FULL      |
 | -304    | ERR\_ASSIGNMENT\_FAILED          |
+| -304    | ERR\_ASSIGNMENT\_UNUSED          |
 | -401    | ERR\_CONTROL\_CHAIN\_UNAVAILABLE |
 | -402    | ERR\_LINK\_UNAVAILABLE           |
+| -403    | ERR\_HMI\_UNAVAILABLE            |
+| -404    | ERR\_EXTERNAL\_UI\_UNAVAILABLE   |
 | -901    | ERR\_MEMORY\_ALLOCATION          |
 | -902    | ERR\_INVALID\_OPERATION          |
 

--- a/src/effects.c
+++ b/src/effects.c
@@ -4434,7 +4434,7 @@ int effects_finish(int close_client)
     sem_post(&g_postevents_semaphore);
     pthread_join(g_postevents_thread, NULL);
 
-    if (close_client)
+    if (close_client && g_jack_global_client != NULL && strcmp(jack_get_client_name(g_jack_global_client), "mod-host") == 0)
         monitor_client_stop();
 
     effects_remove(REMOVE_ALL);

--- a/src/effects.c
+++ b/src/effects.c
@@ -5948,6 +5948,22 @@ int effects_remove(int effect_id)
         }
     }
 
+    // discard events that arrived between the pre-drain and jack_client_close above
+    {
+        struct list_head stale;
+        INIT_LIST_HEAD(&stale);
+        pthread_mutex_lock(&g_rtsafe_mutex);
+        list_splice_init(&g_rtsafe_list, &stale);
+        pthread_mutex_unlock(&g_rtsafe_mutex);
+        struct list_head *it, *it2;
+        list_for_each_safe(it, it2, &stale)
+        {
+            postponed_event_list_data *const ep =
+                list_entry(it, postponed_event_list_data, siblings);
+            rtsafe_memory_pool_deallocate(g_rtsafe_mem_pool, ep);
+        }
+    }
+
     // clear param_set cache
     effects_set_parameter(-1, NULL, 0.f);
 

--- a/src/mod-host.c
+++ b/src/mod-host.c
@@ -33,13 +33,13 @@
 #include <stdlib.h>
 #include <fcntl.h>
 #include <string.h>
-#include <unistd.h>
 #include <getopt.h>
 #include <jack/jack.h>
 #include <pthread.h>
 #include <signal.h>
 
 #ifndef SKIP_READLINE
+#include <unistd.h>
 #include <readline/readline.h>
 #include <readline/history.h>
 #endif

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -56,9 +56,6 @@
 #define MESSAGE_FEW_ARGUMENTS       "few arguments"
 #define MESSAGE_INVALID_ARGUMENT    "invalid argument"
 
-// defines the function to send responses to sender
-#define SEND_TO_SENDER(id,msg,len)  socket_send((id),(msg),(len)+1)
-
 
 /*
 ************************************************************************************************************************


### PR DESCRIPTION
Fixes a race between `PortRegistration()` and `effects_remove()` that causes heap corruption and `SIGSEGV` when switching pedalboards while an rtmidi device is open.

Fixes #94 

### Author checklist

- [ ] verify fix on-device
- [ ] stress test