### PR TITLE
Fix three crashes found running a large plugin catalog through mod-host

### DIFF
--- a/src/effects.c
+++ b/src/effects.c
@@ -971,9 +971,19 @@ static void AllocatePortBuffers(effect_t* effect, int in_size, int out_size)
 
     for (i = 0; i < effect->event_ports_count; i++)
     {
-        const int size = effect->event_ports[i]->flow == FLOW_INPUT ? in_size : out_size;
+        int size = effect->event_ports[i]->flow == FLOW_INPUT ? in_size : out_size;
+
+        /* A zero size means "leave this port's buffer as it already is" -- BufferSize() passes it
+           that way for ports whose size is pinned to something other than the default. Skipping
+           is only safe once the port HAS a buffer; a port that never got one needs the same
+           default the output side already has below. */
         if (size == 0)
-            continue;
+        {
+            if (effect->event_ports[i]->evbuf != NULL)
+                continue;
+            size = g_midi_buffer_size * 16; // 16 taken from jalv source code
+        }
+
         lv2_evbuf_free(effect->event_ports[i]->evbuf);
         effect->event_ports[i]->evbuf = lv2_evbuf_new(
             size,

--- a/src/effects.c
+++ b/src/effects.c
@@ -5108,6 +5108,23 @@ int effects_add(const char *uri, int instance)
         }
     }
 
+    /* lilv can undercount a plugin's ports relative to what its compiled LV2 descriptor actually
+       has (some bundles' Turtle reuses one blank node as the lv2:port of more than one plugin
+       subject). When that happens, some of what jack_activate() below wires up is never
+       lilv_instance_connect_port()-ed, and the real-time thread calls into the plugin with an
+       unconnected port. Refuse rather than activate a plugin lilv could not fully describe. */
+    if (ports_count == 0 ||
+        (audio_ports_count + control_ports_count + cv_ports_count + event_ports_count) != ports_count)
+    {
+        fprintf(stderr, "effects_add: lilv reported %u port(s) for %s but only classified "
+                         "%u (audio) + %u (control) + %u (cv) + %u (event) -- refusing to "
+                         "activate an effect lilv could not fully describe\n",
+                ports_count, uri, audio_ports_count, control_ports_count, cv_ports_count,
+                event_ports_count);
+        error = ERR_LV2_INSTANTIATION;
+        goto error;
+    }
+
     // special ports
     {
         const LilvPort* enabled_port = lilv_plugin_get_port_by_designation(plugin, g_lilv_nodes.input, g_lilv_nodes.enabled);

--- a/src/worker.c
+++ b/src/worker.c
@@ -61,7 +61,13 @@ void worker_init(worker_t *worker, LilvInstance *instance, const LV2_Worker_Inte
     worker->iface = iface;
     worker->instance = instance;
     sem_init(&worker->sem, 0, 0);
-    zix_thread_create(&worker->thread, size + sizeof(void*) * 4, worker_func, worker);
+    const ZixStatus thread_status =
+        zix_thread_create(&worker->thread, size + sizeof(void*) * 4, worker_func, worker);
+    worker->thread_started = (thread_status == ZIX_STATUS_SUCCESS);
+    if (!worker->thread_started) {
+        fprintf(stderr, "worker_init: zix_thread_create() failed (status %d) -- "
+                         "this plugin's LV2 worker extension will not run\n", (int)thread_status);
+    }
     worker->requests  = jack_ringbuffer_create(size);
     worker->responses = jack_ringbuffer_create(size);
     worker->response  = malloc(size);
@@ -72,9 +78,13 @@ void worker_init(worker_t *worker, LilvInstance *instance, const LV2_Worker_Inte
 void worker_finish(worker_t *worker)
 {
     worker->exit = true;
-    if (worker->requests) {
+    /* Only join a thread zix_thread_create() actually reported starting -- `requests` is
+       allocated unconditionally above and is not evidence of that (see worker_init()). */
+    if (worker->thread_started) {
         sem_post(&worker->sem);
         zix_thread_join(worker->thread, NULL);
+    }
+    if (worker->requests) {
         jack_ringbuffer_free(worker->requests);
         jack_ringbuffer_free(worker->responses);
         free(worker->response);

--- a/src/worker.h
+++ b/src/worker.h
@@ -27,6 +27,8 @@ typedef struct WORKER_T {
     void *response;
     sem_t sem;
     ZixThread thread;
+    /* True only once zix_thread_create() reports success for `thread` above. */
+    bool thread_started;
     const LV2_Worker_Interface *iface;
     LilvInstance *instance;
     bool exit;

--- a/src/zix/thread.h
+++ b/src/zix/thread.h
@@ -22,6 +22,8 @@
 #else
 #    include <errno.h>
 #    include <pthread.h>
+#    include <stdio.h>
+#    include <string.h>
 #endif
 
 #include "common.h"
@@ -94,9 +96,16 @@ zix_thread_create(ZixThread* thread,
 {
     pthread_attr_t attr;
     pthread_attr_init(&attr);
-    pthread_attr_setstacksize(&attr, stack_size);
+    const int ss_ret = pthread_attr_setstacksize(&attr, stack_size);
+    if (ss_ret) {
+        fprintf(stderr, "zix_thread_create: pthread_attr_setstacksize(%zu) failed: %s\n",
+                stack_size, strerror(ss_ret));
+    }
 
     const int ret = pthread_create(thread, &attr, function, arg);
+    if (ret) {
+        fprintf(stderr, "zix_thread_create: pthread_create() failed: %s\n", strerror(ret));
+    }
     pthread_attr_destroy(&attr);
 
     if (ret == EAGAIN) {


### PR DESCRIPTION
Found while running a large local plugin catalog (~950 LV2 plugins) through mod-host repeatedly, add/connect/remove/quit for each. Three independent crashes, each pinned with gdb against a debug build, not guessed.

1. **worker_finish() joins a thread that was never started.** worker_init() calls zix_thread_create() but never checks whether it actually started a thread. When it fails, worker_finish() still calls zix_thread_join() on an uninitialized pthread_t, which segfaults inside glibc. Reproduced against `http://lsp-plug.in/plugins/lv2/para_equalizer_x16_stereo`, where pthread_create() itself returns EINVAL for this plugin's worker thread.

2. **NULL event buffer on an unsized atom input port.** AllocatePortBuffers() skips allocating a buffer for any event port handed a zero size. effects_add() passes 0 for any atom input port that declares neither an lv2:control designation nor rsz:minimumSize — the output side already had a default, the input side didn't. That port reaches jack_activate() with a NULL buffer, and ProcessPlugin() dereferences it. Hits a whole class of plugins with a bare MIDI/atom input port and no size hint — x42's midifilter set (33 plugins) among them.

3. **A plugin whose Turtle lilv can't fully describe gets activated anyway.** Some bundles reuse one blank node as the lv2:port of more than one plugin subject, so lilv reports fewer ports than the plugin binary's compiled LV2 descriptor actually has. mod-host now refuses to activate a plugin whose classified port count doesn't match what lilv reported, rather than running an effect it knows it failed to wire up. Reproduced against the ll-plugins.nongnu.org math-constant/math-function set (51 catalog URIs).

Each commit has the reproduction, root cause, and fix in its message. All three were sabotage-verified (revert the fix, confirm the crash returns at the same rate; restore it, confirm clean) and tested against the ~950-plugin catalog (calf, mda, eq10q, x42, gareus.org, lsp-plugins, rubberband) with no regressions.

Two other crashes turned up in the same sweep that are **not** fixed here because they aren't mod-host bugs: a heap-corruption crash in noise-repellent that reproduces identically under a second LV2 host (jalv), and a double-free inside PipeWire's own JACK-compat shim (`jack_client_close` → `pw_memmap_free`) that showed up across several unrelated plugins on `remove`/`quit`. Happy to share the backtraces if useful for a report against either of those projects.